### PR TITLE
Removendo formulário do início do chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,22 +30,22 @@ Com as configurações padrões, acessando http://localhost:3000/ você terá ac
 ## Adicionando o bot
 
 Para adicionar o bot ao seu Rocket Chat, você deve criar uma conta de administrador. Logo, na tela inicial do Rocket Chat clique em 
-Register a new account, e preencha as informações, não precisa ser utilizado um e-mail real.
+**Register a new account**, e preencha as informações, não precisa ser utilizado um e-mail real.
 
 ![New account example](https://gitlab.com/lappis-unb/minc/rouanet-bot/wikis/new_account.png)
 
 Após preencher as informações, clique em REGISTER A NEW ACCOUNT, e em seguida, volte ao login e entre utilizando as 
 informações preenchidas anteriormente.
 
-No menu lateral esquerdo, ao lado do nome da sua conta, clique na seta para baixo, e clique na opção Administration.
+No menu lateral esquerdo, ao lado do nome da sua conta, clique na seta para baixo, e clique na opção **Administration**.
 
 ![Adm option](https://gitlab.com/lappis-unb/minc/rouanet-bot/wikis/adm_sidebar.png)
 
-Logo em seguida, clique na opção Users. Aparecerá uma barra lateral direita com uma opção com um +. Clique nesta opção e preencha as informações 
+Logo em seguida, clique na opção **Users**. Aparecerá uma barra lateral direita com uma opção com um +. Clique nesta opção e preencha as informações 
 conforme a imagem a seguir. O nome do bot pode ser alterado, mas devem ser usados o usuário e senha que estão definidos nas variáveis
 ROCKETCHAT_USER e ROCKETCHAT_PASSWORD no arquivo docker-compose.yml. Por padrão, o usuário e senha são, botnat e botnatpass, respectivamente.
 
-Para adicionar a role ao bot, clique na opção Select a Role, selecione bot e clique na opção ADD ROLE. Por fim, clique em Save.
+Para adicionar a role ao bot, clique na opção **Select a Role**, selecione bot e clique na opção ADD ROLE. Por fim, clique em **Save**.
 
 ![Adding bot tutorial](https://gitlab.com/lappis-unb/minc/rouanet-bot/wikis/adding_bot.png)
 
@@ -54,33 +54,34 @@ Agora você já está apto a conversar com o bot diretamente, ou pelos canais us
 ### Livechat
 
 O livechat permite que seja criada uma janela de conversa com o bot integrável à outras páginas. Para ativá-lo acesse novamente a opção 
-Administration, clicando na seta para baixo, ao lado do nome da sua conta, no meu lateral esquerdo. Em seguida, clique na opção Livechat.
+**Administration**, clicando na seta para baixo, ao lado do nome da sua conta, no meu lateral esquerdo. Em seguida, clique na opção **Livechat**.
 
 ![Livechat option on adm menu](https://gitlab.com/lappis-unb/minc/rouanet-bot/wikis/livechat_sidebar.png)
 
-Na tela seguinte, marque a opção Livechat enabled como True e clique em SAVE CHANGES.
+Na tela seguinte, marque a opção **Livechat enabled** como True, e a opção **Show pre-registration form** como False, para que não seja mostrado
+o formulário solicitando e-mail e senha no chat. Clique em SAVE CHANGES.
 
 ![Livechat activation screen](https://gitlab.com/lappis-unb/minc/rouanet-bot/wikis/active_livechat.png)
 
-Fehe o menu lateral esquerdo de administração e clique novamente na seta para baixo, ao lado do nome da sua conta. Clique na opção Livechat.
+Fehe o menu lateral esquerdo de administração e clique novamente na seta para baixo, ao lado do nome da sua conta. Clique na opção **Livechat**.
 
 ![Livechat option](https://gitlab.com/lappis-unb/minc/rouanet-bot/wikis/livechat_option.png)
 
-No menu lateral esquerdo Livechat, selecione a opção User Management. Você deve adicionar o bot como um agente, logo procure por botnat, 
+No menu lateral esquerdo **Livechat**, selecione a opção **User Management**. Você deve adicionar o bot como um agente, logo procure por botnat, 
 e em seguida clique em ADD.
 
 ![Adding bot as agent](https://gitlab.com/lappis-unb/minc/rouanet-bot/wikis/add_agent.png)
 
-Agora é necessário criar um departamento. No menu lateral esquerdo, clique em Departments, e em seguida em NEW DEPARTMENT.
+Agora é necessário criar um departamento. No menu lateral esquerdo, clique em **Departments**, e em seguida em NEW DEPARTMENT.
 
 ![Adding bot as agent](https://gitlab.com/lappis-unb/minc/rouanet-bot/wikis/new_department.png)
 
-Na tela seguinte, preencha um nome e uma descrição para o departamento e adicione o bot clicando no bot desejado em Available agents.
-Em seguida clique em Save.
+Na tela seguinte, preencha um nome e uma descrição para o departamento e adicione o bot clicando no bot desejado em **Available agents**.
+Em seguida clique em **Save**.
 
 ![Create new department](https://gitlab.com/lappis-unb/minc/rouanet-bot/wikis/add_agent_to_department.png)
 
-No menu lateral esquerdo, clique em Installation. Agora é só copiar o código exibido e colar no site o qual você deseja integrar 
+No menu lateral esquerdo, clique em **Installation**. Agora é só copiar o código exibido e colar no site o qual você deseja integrar 
 a janela de conversa com o bot.
 
 ![Installation code](https://gitlab.com/lappis-unb/minc/rouanet-bot/wikis/installation.png)

--- a/training_data/corpus.yml
+++ b/training_data/corpus.yml
@@ -50,7 +50,7 @@ interactions:
       - oi como vai
       - tudo bem
     answer:
-      - olá $user, eu vou bem e você?
+      - olá, eu vou bem e você?
       - estou feliz de estar aqui =)
     next:
       interactions:
@@ -80,11 +80,11 @@ interactions:
       - bom dia pessoal
       - good morning
     answer:
-      - Olá $user, um ótimo dia para você!
-      - Bom dia $user, já deu uma olhada lá fora?
+      - Olá, um ótimo dia para você!
+      - Bom dia, já deu uma olhada lá fora?
       - Está um dia ótimo para navegar na internet
-      - Bom demais $user ;)
-      - está melhor agora que você chegou $user
+      - Bom demais ;)
+      - está melhor agora que você chegou
     event: respond
     type: random
 
@@ -93,11 +93,11 @@ interactions:
       - boa tarde
       - boa tarde galera
     answer:
-      - Olá $user, uma tarde fantástica para você!
-      - boa tarde $user, já almoçou?
+      - Olá, uma tarde fantástica para você!
+      - boa tarde, já almoçou?
       - Está uma tarde ótima para um _sleep mode_ rápido ;)
-      - Taarrrdee $user
-      - $user já estava sentindo sua falta
+      - Taarrrdee
+      - já estava sentindo sua falta
     event: respond
     type: random
 
@@ -106,9 +106,9 @@ interactions:
       - boa noite
       - até mais e boa noite
     answer:
-      - Uma boa noite pra ti também $user!
-      - Boa noite $user
-      - Está uma noite boa mesmo $user
+      - Uma boa noite pra ti também!
+      - Boa noite
+      - Está uma noite boa mesmo
     event: respond
     type: random
 


### PR DESCRIPTION
Este PR resolve #3 da seguinte forma:

-  Na criação do Livechat, há uma opção para não mostrar o formulário. O README.md foi atualizado, mostrando como fazer esta configuração.

- Como não haverá um usuário logado, todas as referências ao $user foram removidas do YAML